### PR TITLE
Update image URLs to thinkjava2

### DIFF
--- a/trinket/maketemplates.py
+++ b/trinket/maketemplates.py
@@ -81,7 +81,7 @@ with open(index_file) as index:
         with open(output_dir + newfile, 'w') as nf:
             template = """
 
-{% extends 'books/thinkjava/base.html' %}
+{% extends 'books/thinkjava2/base.html' %}
 {% block chaptercontent %}
 <div class="row">
 <div class="columns small-12">
@@ -110,7 +110,7 @@ $toc$
             # form valid iframes
             template = re.sub(r'<iframe(.*?)=""/>', '<iframe\g<1>></iframe>', template)
             # change image paths
-            template = re.sub(r'<img src="(.*?)"\w*?/?>', '<img src="https://trinket-app-assets.trinket.io/thinkjava/\g<1>"/>', template)
+            template = re.sub(r'<img src="(.*?)"\w*?/?>', '<img src="https://trinket-app-assets.trinket.io/thinkjava2/\g<1>"/>', template)
             #print(template)
 
             # replace tabs and newlines


### PR DESCRIPTION
Amazingly, this was the only change needed :)  This should get deployed to production soon, but I wanted to make sure I sent this upstream as well.

The initial errors I ran into with not generating the pngs came from not having ImageMagick installed on this dev box.  I hadn't noticed it since that's only needed to generate the PNGs once, for upload to AWS.

About PNGs: Please let me know if/when you add, remove, or reorder image assets- it'll be a (currently) manual process to update them. Also, AWS S3 assets are aggressively edge cached, so even after I update them it's possible the images will show up incorrectly for some users (e.g. 005.png may still point to what *should* be now called 006.png, from the cache, if you insert a new fifth image).  I believe may be ways to purge the cache, but if you anticipate updating image assets often we'll probably need to get a cachebusting naming convention built into the trinket script somewhere (perhaps involving the book version number, with a convention to update that version whenever image assets are modified).  Hevea's serial number naming convention won't cut it.  Should be easy to append a version number to each image filename and img src, but we'll cross that bridge if we come to it.