### PR TITLE
Fix definition of method signature

### DIFF
--- a/appb.tex
+++ b/appb.tex
@@ -412,7 +412,7 @@ Comments that describe the technical operation of a class or method.
 A tool that reads Java source code and generates documentation in HTML format.
 
 \term{signature}
-The first line of a method that defines its name, return type, and parameters.
+The first line of a method that defines its name and parameters.
 
 \term{tag}
 A label that begins with an at sign (\java{@}) and is used by Javadoc to organize documentation into sections.


### PR DESCRIPTION
Return type is not part of signature; fix definition at end of chapter.